### PR TITLE
Allow Setting Customer on Cart

### DIFF
--- a/src/lib/CartService.ts
+++ b/src/lib/CartService.ts
@@ -172,3 +172,34 @@ export async function updateCouponCodes(
 
 	return result.body;
 }
+
+export async function setCustomer(
+	cartId: string,
+	cartVersion: number,
+	customerId: string,
+	customerEmail: string
+) {
+	const apiRoot = createClient();
+
+	const result = await apiRoot
+		.carts()
+		.withId({ ID: cartId })
+		.post({
+			body: {
+				version: cartVersion,
+				actions: [
+					{
+						action: 'setCustomerId',
+						customerId
+					},
+					{
+						action: 'setCustomerEmail',
+						email: customerEmail
+					}
+				]
+			}
+		})
+		.execute();
+
+	return result.body;
+}

--- a/src/lib/CartService.ts
+++ b/src/lib/CartService.ts
@@ -2,14 +2,21 @@ import { createClient } from '$lib/CreateClient';
 import type { ClientResponse } from '@commercetools/ts-client';
 import type { CartCouponCode } from './types/DovetechCouponCodes';
 
-export async function createCart(currency: string, country: string) {
+export async function createCart(
+	currency: string,
+	country: string,
+	customerId?: string,
+	customerEmail?: string
+) {
 	const apiRoot = createClient();
 	const response = await apiRoot
 		.carts()
 		.post({
 			body: {
 				currency,
-				country
+				country,
+				customerId,
+				customerEmail
 			}
 		})
 		.execute();

--- a/src/lib/CartService.ts
+++ b/src/lib/CartService.ts
@@ -176,8 +176,8 @@ export async function updateCouponCodes(
 export async function setCustomer(
 	cartId: string,
 	cartVersion: number,
-	customerId: string,
-	customerEmail: string
+	customerId: string | undefined,
+	customerEmail: string | undefined
 ) {
 	const apiRoot = createClient();
 
@@ -190,7 +190,7 @@ export async function setCustomer(
 				actions: [
 					{
 						action: 'setCustomerId',
-						customerId
+						customerId: customerId
 					},
 					{
 						action: 'setCustomerEmail',

--- a/src/lib/CustomerService.ts
+++ b/src/lib/CustomerService.ts
@@ -1,0 +1,9 @@
+import { createClient } from './CreateClient';
+
+export const getCustomer = async (customerId: string) => {
+	const apiRoot = createClient();
+
+	const result = await apiRoot.customers().withId({ ID: customerId }).get().execute();
+
+	return result.body;
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -52,6 +52,25 @@
 							{`${data.currentCountry} - ${data.currentCurrency}`}
 						</a>
 
+						<a href="/set-customer" class="p-2 text-gray-400 hover:text-gray-500 lg:ml-4">
+							<span class="sr-only">Account</span>
+							<svg
+								class="size-6"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="1.5"
+								stroke="currentColor"
+								aria-hidden="true"
+								data-slot="icon"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+								></path>
+							</svg>
+						</a>
+
 						<!-- Cart -->
 						<div class="ml-4 flow-root lg:ml-6">
 							<a href="/cart" class="group -m-2 flex items-center p-2">

--- a/src/routes/cart/+page.svelte
+++ b/src/routes/cart/+page.svelte
@@ -22,6 +22,7 @@
 			<p class="text-base">Your cart is empty</p>
 		</div>
 	{:else}
+		{cart.customerEmail ? cart.customerEmail : 'no customer on cart'}
 		<div class="mt-12 lg:grid lg:grid-cols-12 lg:items-start lg:gap-x-12 xl:gap-x-16">
 			<section aria-labelledby="cart-heading" class="lg:col-span-7">
 				<h2 id="cart-heading" class="sr-only">Items in your shopping cart</h2>

--- a/src/routes/cart/+page.svelte
+++ b/src/routes/cart/+page.svelte
@@ -22,7 +22,14 @@
 			<p class="text-base">Your cart is empty</p>
 		</div>
 	{:else}
-		{cart.customerEmail ? cart.customerEmail : 'no customer on cart'}
+		<p class="text-sm font-medium text-gray-700">
+			{#if cart.customerEmail}
+				{cart.customerEmail}
+			{:else}
+				no customer on cart
+				<a href="/set-customer" class="text-indigo-600 hover:text-indigo-700">set one?</a>
+			{/if}
+		</p>
 		<div class="mt-12 lg:grid lg:grid-cols-12 lg:items-start lg:gap-x-12 xl:gap-x-16">
 			<section aria-labelledby="cart-heading" class="lg:col-span-7">
 				<h2 id="cart-heading" class="sr-only">Items in your shopping cart</h2>

--- a/src/routes/product/[id]/+page.svelte
+++ b/src/routes/product/[id]/+page.svelte
@@ -59,9 +59,11 @@
 					class="mt-8 flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
 					>Add to cart</button
 				>
-				{#if form?.addToCartError}<p class="mt-2 text-sm text-red-600">
+				{#if form?.addToCartError}
+					<p class="mt-2 text-sm text-red-600">
 						{form.addToCartError}
-					</p>{/if}
+					</p>
+				{/if}
 			</form>
 
 			<!-- Product details -->

--- a/src/routes/set-customer/+page.server.ts
+++ b/src/routes/set-customer/+page.server.ts
@@ -2,6 +2,7 @@ import type { Actions } from './$types';
 import { getCart, setCustomer } from '$lib/CartService';
 import { createClient } from '$lib/CreateClient';
 import { fail } from '@sveltejs/kit';
+import { getCustomer } from '$lib/CustomerService';
 
 export const load = async ({ cookies }) => {
 	const customerId = cookies.get('customerId');
@@ -10,11 +11,9 @@ export const load = async ({ cookies }) => {
 		return { customer: null };
 	}
 
-	const apiRoot = createClient();
+	const customer = await getCustomer(customerId);
 
-	const result = await apiRoot.customers().withId({ ID: customerId }).get().execute();
-
-	return { customer: result.body };
+	return { customer };
 };
 
 export const actions: Actions = {

--- a/src/routes/set-customer/+page.server.ts
+++ b/src/routes/set-customer/+page.server.ts
@@ -1,0 +1,53 @@
+import type { Actions } from './$types';
+import { getCart, setCustomer } from '$lib/CartService';
+import { createClient } from '$lib/CreateClient';
+import { fail } from '@sveltejs/kit';
+
+export const actions: Actions = {
+	default: async ({ request, cookies }) => {
+		const formData = await request.formData();
+		const email = formData.get('email') as string;
+
+		const cartId = cookies.get('cartId');
+		const cart = await getCart(cartId!);
+
+		if (!email) {
+			return { error: 'Missing required fields' };
+		}
+
+		if (!cart) {
+			return { error: 'Cart not found' };
+		}
+
+		const apiRoot = createClient();
+
+		const result = await apiRoot
+			.customers()
+			.search() // needs customers to be indexed, just lookup a customer by email?
+			.post({
+				body: {
+					query: {
+						fullText: {
+							field: 'email',
+							value: email
+						}
+					}
+				}
+			})
+			.execute();
+
+		if (result.body.results.length !== 1) {
+			return fail(400, { error: 'Customer not found' });
+		}
+
+		const customer = result.body.results[0];
+		console.log(customer);
+
+		try {
+			const updatedCart = await setCustomer(cart.id, cart.version, customer.id, email);
+			return { cart: updatedCart };
+		} catch (error) {
+			return { error: 'Failed to set customer ID' };
+		}
+	}
+};

--- a/src/routes/set-customer/+page.server.ts
+++ b/src/routes/set-customer/+page.server.ts
@@ -35,10 +35,11 @@ export const actions: Actions = {
 
 		try {
 			const updatedCart = await setCustomer(cart.id, cart.version, undefined, undefined);
+
 			return { cart: updatedCart };
 		} catch (error) {
 			console.error(error);
-			return { error: 'Failed to clear customer on cart' };
+			return fail(500, { clearCustomerError: 'Failed to clear customer on cart' });
 		}
 	},
 	setCustomer: async ({ request, cookies }) => {
@@ -46,7 +47,7 @@ export const actions: Actions = {
 		const email = formData.get('email') as string;
 
 		if (!email) {
-			return { error: 'Missing required fields' };
+			return { setCustomerError: 'Enter an email' };
 		}
 
 		const apiRoot = createClient();
@@ -61,7 +62,10 @@ export const actions: Actions = {
 			.execute();
 
 		if (result.body.results.length !== 1) {
-			return fail(400, { error: 'Customer not found' });
+			return fail(400, {
+				setCustomerError:
+					'Customer not found. Find a valid customer in the commercetools Merchant Center'
+			});
 		}
 
 		const customer = result.body.results[0];
@@ -85,7 +89,7 @@ export const actions: Actions = {
 			return { cart: updatedCart };
 		} catch (error) {
 			console.error(error);
-			return { error: 'Failed to set customer on cart' };
+			return fail(500, { setCustomerError: 'Failed to set customer on cart' });
 		}
 	}
 };

--- a/src/routes/set-customer/+page.server.ts
+++ b/src/routes/set-customer/+page.server.ts
@@ -35,7 +35,6 @@ export const actions: Actions = {
 		}
 
 		const customer = result.body.results[0];
-		console.log(customer);
 
 		try {
 			const updatedCart = await setCustomer(cart.id, cart.version, customer.id, customer.email);

--- a/src/routes/set-customer/+page.server.ts
+++ b/src/routes/set-customer/+page.server.ts
@@ -23,15 +23,9 @@ export const actions: Actions = {
 
 		const result = await apiRoot
 			.customers()
-			.search() // needs customers to be indexed, just lookup a customer by email?
-			.post({
-				body: {
-					query: {
-						fullText: {
-							field: 'email',
-							value: email
-						}
-					}
+			.get({
+				queryArgs: {
+					where: `email="${email}"`
 				}
 			})
 			.execute();
@@ -44,7 +38,7 @@ export const actions: Actions = {
 		console.log(customer);
 
 		try {
-			const updatedCart = await setCustomer(cart.id, cart.version, customer.id, email);
+			const updatedCart = await setCustomer(cart.id, cart.version, customer.id, customer.email);
 			return { cart: updatedCart };
 		} catch (error) {
 			return { error: 'Failed to set customer ID' };

--- a/src/routes/set-customer/+page.svelte
+++ b/src/routes/set-customer/+page.svelte
@@ -4,28 +4,69 @@
 	let { data } = $props();
 </script>
 
-{#if data.customer}
-	<p>Current Customer: {data.customer.email}</p>
-	<form method="post" action="?/clearCustomer" use:enhance>
-		<button type="submit">Clear Customer</button>
+<div class="mx-auto max-w-2xl px-4 pt-10">
+	<div class="text-center">
+		<h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Set Customer</h1>
+
+		<p class="mt-2 text-sm text-gray-500">
+			Use this page to set a customer on the cart. This simulates logging in as the user
+		</p>
+
+		<p class="mt-2 text-sm text-gray-500">
+			If you don't have a cart, the user will be set on the cart when the cart is created
+		</p>
+	</div>
+
+	{#if data.customer}
+		<div class="flex items-center justify-center bg-white p-8">
+			<div class="mx-auto flex w-full max-w-xs flex-col gap-4 rounded-md border p-4">
+				<h2 class="text-base/7 font-semibold text-gray-900">Current Customer</h2>
+				<p class="mt-1 text-sm/6 text-gray-600">{data.customer.email}</p>
+				<form method="post" action="?/clearCustomer" use:enhance>
+					<button
+						type="submit"
+						class="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm/6 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+						>Clear Current Customer</button
+					>
+				</form>
+			</div>
+		</div>
+	{/if}
+
+	<form
+		method="post"
+		action="?/setCustomer"
+		use:enhance={() => {
+			return async ({ update, result }) => {
+				// if (result.type === 'success' && result.data?.cart) {
+				// 	console.log(result.data.cart.);
+				// }
+
+				await update();
+			};
+		}}
+	>
+		<div class="flex items-center justify-center bg-white p-8">
+			<div class="mx-auto flex w-full max-w-xs flex-col gap-4 rounded-md border p-4">
+				<h2 class="text-base/7 font-semibold text-gray-900">Set Customer</h2>
+				<div>
+					<label for="email" class="block text-sm/6 font-medium text-gray-900">Email</label>
+					<input
+						type="text"
+						id="email"
+						name="email"
+						class="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm/6"
+						required
+					/>
+				</div>
+				<div>
+					<button
+						type="submit"
+						class="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm/6 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+						>Set Customer</button
+					>
+				</div>
+			</div>
+		</div>
 	</form>
-{/if}
-
-<form
-	method="post"
-	action="?/setCustomer"
-	use:enhance={() => {
-		return async ({ update, result }) => {
-			// if (result.type === 'success' && result.data?.cart) {
-			// 	console.log(result.data.cart.);
-			// }
-
-			await update();
-		};
-	}}
->
-	<label for="email">Customer Email:</label>
-	<input type="text" id="email" name="email" value="stephen.upchurch@dovetech.com" required />
-
-	<button type="submit">Set Customer</button>
-</form>
+</div>

--- a/src/routes/set-customer/+page.svelte
+++ b/src/routes/set-customer/+page.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+</script>
+
+<form
+	method="post"
+	use:enhance={() => {
+		return async ({ update, result }) => {
+			// if (result.type === 'success' && result.data?.cart) {
+			// 	console.log(result.data.cart.);
+			// }
+
+			await update();
+		};
+	}}
+>
+	<label for="email">Customer Email:</label>
+	<input type="text" id="email" name="email" value="stephen.upchurch@dovetech.com" required />
+
+	<button type="submit">Set Customer</button>
+</form>

--- a/src/routes/set-customer/+page.svelte
+++ b/src/routes/set-customer/+page.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+
+	let { data } = $props();
 </script>
+
+{#if data.customer}
+	<p>Current Customer: {data.customer.email}</p>
+	<form method="post" action="?/clearCustomer" use:enhance>
+		<button type="submit">Clear Customer</button>
+	</form>
+{/if}
 
 <form
 	method="post"
+	action="?/setCustomer"
 	use:enhance={() => {
 		return async ({ update, result }) => {
 			// if (result.type === 'success' && result.data?.cart) {

--- a/src/routes/set-customer/+page.svelte
+++ b/src/routes/set-customer/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { setCart } from '$lib/Cart.svelte';
+	import type { Cart } from '@commercetools/platform-sdk';
 
-	let { data } = $props();
+	let { data, form } = $props();
+	let clearingCustomer = $state(false);
+	let settingCustomer = $state(false);
 </script>
 
 <div class="mx-auto max-w-2xl px-4 pt-10">
@@ -22,12 +26,32 @@
 			<div class="mx-auto flex w-full max-w-xs flex-col gap-4 rounded-md border p-4">
 				<h2 class="text-base/7 font-semibold text-gray-900">Current Customer</h2>
 				<p class="mt-1 text-sm/6 text-gray-600">{data.customer.email}</p>
-				<form method="post" action="?/clearCustomer" use:enhance>
+				<form
+					method="post"
+					action="?/clearCustomer"
+					use:enhance={() => {
+						clearingCustomer = true;
+						return async ({ update, result }) => {
+							if (result.type === 'success' && result.data?.cart) {
+								setCart(result.data.cart as Cart);
+							}
+
+							await update();
+							clearingCustomer = false;
+						};
+					}}
+				>
 					<button
 						type="submit"
-						class="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm/6 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+						disabled={clearingCustomer}
+						class="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm/6 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
 						>Clear Current Customer</button
 					>
+					{#if form?.clearCustomerError}
+						<p class="mt-2 text-sm text-red-600">
+							{form.clearCustomerError}
+						</p>
+					{/if}
 				</form>
 			</div>
 		</div>
@@ -37,12 +61,14 @@
 		method="post"
 		action="?/setCustomer"
 		use:enhance={() => {
+			settingCustomer = true;
 			return async ({ update, result }) => {
-				// if (result.type === 'success' && result.data?.cart) {
-				// 	console.log(result.data.cart.);
-				// }
+				if (result.type === 'success' && result.data?.cart) {
+					setCart(result.data.cart as Cart);
+				}
 
 				await update();
+				settingCustomer = false;
 			};
 		}}
 	>
@@ -56,13 +82,19 @@
 						id="email"
 						name="email"
 						class="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm/6"
-						required
 					/>
+					{#if form?.setCustomerError}
+						<p class="mt-2 text-sm text-red-600">
+							{form.setCustomerError}
+						</p>
+					{/if}
 				</div>
+
 				<div>
 					<button
 						type="submit"
-						class="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm/6 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+						disabled={settingCustomer}
+						class="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm/6 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
 						>Set Customer</button
 					>
 				</div>


### PR DESCRIPTION
Add a page to allow specifying the email address of a customer. The customer ID is stored in a cookie so we can set it on the cart later if there isn't one already.

This is useful for testing customer specific discounts and customer based loyalty schemes