### PR TITLE
updatest to read and remove coupons from an array of strings instead …

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The cart page allows you to test out the Dovetech functionality by viewing disco
 
 The main area of customisation is the coupon codes functionality. commercetools doesn't allow changing the provider of coupon codes so we need to store them in a custom field on the cart and update the UI to use this.
 
-Coupon codes are stored on the cart using the `dovetech-discounts-coupon-codes` custom field. This is an array of coupon code objects serialised in JSON.
+Coupon codes are stored on the cart using the `dovetech-discounts-coupon-codes` custom field. The type of this field is a set of strings.
 
 Coupon codes are added to the cart using the `dovetech-discounts-cart-action` custom field. This is a JSON object with the following structure:
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The cart page allows you to test out the Dovetech functionality by viewing disco
 
 The main area of customisation is the coupon codes functionality. commercetools doesn't allow changing the provider of coupon codes so we need to store them in a custom field on the cart and update the UI to use this.
 
-Coupon codes are stored on the cart using the `dovetech-discounts-couponCodes` custom field. This is an array of coupon code objects serialised in JSON.
+Coupon codes are stored on the cart using the `dovetech-discounts-coupon-codes` custom field. This is an array of coupon code objects serialised in JSON.
 
-Coupon codes are added to the cart using the `dovetech-discounts-cartAction` custom field. This is a JSON object with the following structure:
+Coupon codes are added to the cart using the `dovetech-discounts-cart-action` custom field. This is a JSON object with the following structure:
 
 ```json
 {
@@ -45,11 +45,11 @@ Coupon codes are added to the cart using the `dovetech-discounts-cartAction` cus
 
 When a call is made to update the cart, commercetools calls the service in the Dovetech connector (using an API extension) to validate the coupon code.
 
-Valid coupon codes are added to the `dovetech-discounts-couponCodes` field.
+Valid coupon codes are added to the `dovetech-discounts-coupon-codes` field.
 
 If a coupon code isn't valid an error with status 400 is returned and the coupon code is not added to the cart.
 
-Coupon codes can be removed from the cart by updating the `dovetech-discounts-couponCodes` custom field.
+Coupon codes can be removed from the cart by updating the `dovetech-discounts-coupon-codes` custom field.
 
 ### Customers
 

--- a/src/lib/CartHelpers.ts
+++ b/src/lib/CartHelpers.ts
@@ -1,7 +1,7 @@
 import type { Cart, LineItem } from '@commercetools/platform-sdk';
 
 export const getCouponCodes = (cart: Cart): string[] => {
-	return cart.custom?.fields['dovetech-discounts-couponCodes'] ?? '';
+	return cart.custom?.fields['dovetech-discounts-coupon-codes'] ?? '';
 };
 
 export const getCartSubtotal = (cart: Cart | undefined): number => {

--- a/src/lib/CartHelpers.ts
+++ b/src/lib/CartHelpers.ts
@@ -1,14 +1,7 @@
 import type { Cart, LineItem } from '@commercetools/platform-sdk';
-import type { CartCouponCode } from './types/DovetechCouponCodes';
 
-export const getCouponCodes = (cart: Cart): CartCouponCode[] => {
-	const serialisedCodes = cart.custom?.fields['dovetech-discounts-couponCodes'] ?? '';
-
-	if (serialisedCodes) {
-		return JSON.parse(serialisedCodes);
-	}
-
-	return [];
+export const getCouponCodes = (cart: Cart): string[] => {
+	return cart.custom?.fields['dovetech-discounts-couponCodes'] ?? '';
 };
 
 export const getCartSubtotal = (cart: Cart | undefined): number => {

--- a/src/lib/CartService.ts
+++ b/src/lib/CartService.ts
@@ -139,7 +139,7 @@ export async function addCouponCode(cartId: string, cartVersion: number, couponC
 				actions: [
 					{
 						action: 'setCustomField',
-						name: 'dovetech-discounts-cartAction',
+						name: 'dovetech-discounts-cart-action',
 						value: serialisedValue
 					}
 				]
@@ -166,7 +166,7 @@ export async function updateCouponCodes(
 				actions: [
 					{
 						action: 'setCustomField',
-						name: 'dovetech-discounts-couponCodes',
+						name: 'dovetech-discounts-coupon-codes',
 						value: couponCodes
 					}
 				]

--- a/src/lib/CartService.ts
+++ b/src/lib/CartService.ts
@@ -1,6 +1,5 @@
 import { createClient } from '$lib/CreateClient';
 import type { ClientResponse } from '@commercetools/ts-client';
-import type { CartCouponCode } from './types/DovetechCouponCodes';
 
 export async function createCart(
 	currency: string,
@@ -154,11 +153,9 @@ export async function addCouponCode(cartId: string, cartVersion: number, couponC
 export async function updateCouponCodes(
 	cartId: string,
 	cartVersion: number,
-	couponCodes: CartCouponCode[]
+	couponCodes: string[]
 ) {
 	const apiRoot = createClient();
-
-	const serialisedValue = JSON.stringify(couponCodes);
 
 	const result = await apiRoot
 		.carts()
@@ -170,7 +167,7 @@ export async function updateCouponCodes(
 					{
 						action: 'setCustomField',
 						name: 'dovetech-discounts-couponCodes',
-						value: serialisedValue
+						value: couponCodes
 					}
 				]
 			}

--- a/src/lib/test-carts/cart-with-no-discounts.json
+++ b/src/lib/test-carts/cart-with-no-discounts.json
@@ -158,9 +158,9 @@
 			"id": "51cc98cc-4b3f-4d8b-8320-ec53836c3f88"
 		},
 		"fields": {
-			"dovetech-discounts-couponCodes": "[]",
-			"dovetech-discounts-evaluationResponse": "{\"actions\":[],\"basket\":{\"total\":5.98,\"totalAmountOff\":0,\"items\":[{\"total\":5.98,\"totalAmountOff\":0,\"actions\":[]}]},\"aggregates\":{\"total\":5.98,\"totalAmountOff\":0},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
-			"dovetech-discounts-evaluationCurrency": "EUR"
+			"dovetech-discounts-coupon-codes": "[]",
+			"dovetech-discounts-evaluation-response": "{\"actions\":[],\"basket\":{\"total\":5.98,\"totalAmountOff\":0,\"items\":[{\"total\":5.98,\"totalAmountOff\":0,\"actions\":[]}]},\"aggregates\":{\"total\":5.98,\"totalAmountOff\":0},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
+			"dovetech-discounts-evaluation-currency": "EUR"
 		}
 	},
 	"inventoryMode": "None",

--- a/src/lib/test-carts/cart-with-price-per-quantity-discounts.json
+++ b/src/lib/test-carts/cart-with-price-per-quantity-discounts.json
@@ -251,9 +251,9 @@
 			"id": "51cc98cc-4b3f-4d8b-8320-ec53836c3f88"
 		},
 		"fields": {
-			"dovetech-discounts-couponCodes": "[]",
-			"dovetech-discounts-evaluationResponse": "{\"actions\":[{\"id\":\"72d2965c-f9c8-49cb-9a19-8ea3b3dfbe56\",\"discountId\":\"e919f82b-6f83-4151-a048-4a489721ba50\",\"type\":\"AmountOffLineItem\",\"qualifiedCouponCode\":null,\"amountOffType\":\"PercentOff\",\"value\":100,\"amountOff\":2.99,\"displayMessages\":[]}],\"basket\":{\"total\":5.98,\"totalAmountOff\":2.99,\"items\":[{\"total\":5.98,\"totalAmountOff\":2.99,\"actions\":[{\"id\":\"72d2965c-f9c8-49cb-9a19-8ea3b3dfbe56\",\"subItemId\":1,\"amountOff\":2.99}]}]},\"aggregates\":{\"total\":5.98,\"totalAmountOff\":2.99},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
-			"dovetech-discounts-evaluationCurrency": "EUR"
+			"dovetech-discounts-coupon-codes": "[]",
+			"dovetech-discounts-evaluation-response": "{\"actions\":[{\"id\":\"72d2965c-f9c8-49cb-9a19-8ea3b3dfbe56\",\"discountId\":\"e919f82b-6f83-4151-a048-4a489721ba50\",\"type\":\"AmountOffLineItem\",\"qualifiedCouponCode\":null,\"amountOffType\":\"PercentOff\",\"value\":100,\"amountOff\":2.99,\"displayMessages\":[]}],\"basket\":{\"total\":5.98,\"totalAmountOff\":2.99,\"items\":[{\"total\":5.98,\"totalAmountOff\":2.99,\"actions\":[{\"id\":\"72d2965c-f9c8-49cb-9a19-8ea3b3dfbe56\",\"subItemId\":1,\"amountOff\":2.99}]}]},\"aggregates\":{\"total\":5.98,\"totalAmountOff\":2.99},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
+			"dovetech-discounts-evaluation-currency": "EUR"
 		}
 	},
 	"inventoryMode": "None",

--- a/src/lib/test-carts/cart-with-product-discount.json
+++ b/src/lib/test-carts/cart-with-product-discount.json
@@ -208,9 +208,9 @@
 			"id": "51cc98cc-4b3f-4d8b-8320-ec53836c3f88"
 		},
 		"fields": {
-			"dovetech-discounts-couponCodes": "[]",
-			"dovetech-discounts-evaluationResponse": "{\"actions\":[],\"basket\":{\"total\":110.49,\"totalAmountOff\":0,\"items\":[{\"total\":110.49,\"totalAmountOff\":0,\"actions\":[]}]},\"aggregates\":{\"total\":110.49,\"totalAmountOff\":0},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
-			"dovetech-discounts-evaluationCurrency": "EUR"
+			"dovetech-discounts-coupon-codes": "[]",
+			"dovetech-discounts-evaluation-response": "{\"actions\":[],\"basket\":{\"total\":110.49,\"totalAmountOff\":0,\"items\":[{\"total\":110.49,\"totalAmountOff\":0,\"actions\":[]}]},\"aggregates\":{\"total\":110.49,\"totalAmountOff\":0},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
+			"dovetech-discounts-evaluation-currency": "EUR"
 		}
 	},
 	"inventoryMode": "None",

--- a/src/lib/types/DovetechCouponCodes.ts
+++ b/src/lib/types/DovetechCouponCodes.ts
@@ -1,3 +1,0 @@
-export interface CartCouponCode {
-	code: string;
-}

--- a/src/routes/cart/+page.server.ts
+++ b/src/routes/cart/+page.server.ts
@@ -62,10 +62,8 @@ export const actions = {
 		const data = await request.formData();
 		const couponCode = data.get('coupon-code');
 		const cart = await getCartFromSession(cookies);
-
 		const couponCodes = getCouponCodes(cart);
-		const newCouponCodes = couponCodes.filter((code) => code.code !== couponCode);
-
+		const newCouponCodes = couponCodes.filter((code) => code !== couponCode);
 		try {
 			const updatedCart = await updateCouponCodes(cart.id, cart.version, newCouponCodes);
 

--- a/src/routes/cart/CartCouponCodes.svelte
+++ b/src/routes/cart/CartCouponCodes.svelte
@@ -13,7 +13,7 @@
 <ul class="flex flex-wrap gap-2">
 	{#each couponCodes as coupon}
 		<li class="flex items-center text-sm font-medium">
-			{coupon.code}
+			{coupon}
 			<form
 				method="POST"
 				action="?/removeCouponCode"
@@ -29,7 +29,7 @@
 					};
 				}}
 			>
-				<input type="hidden" name="coupon-code" value={coupon.code} />
+				<input type="hidden" name="coupon-code" value={coupon} />
 				<button
 					type="submit"
 					disabled={removingCode}


### PR DESCRIPTION
Updates to correctly process the change of the custom field "coupon-codes" from an array of objects into an array of strings.
Tested end to end, including the removal of the code from the cart. 

has a dependency with https://github.com/dove-technology/commercetools-campaigns-connector/pull/12
