### PR TITLE
Error Handling Updates

### DIFF
--- a/src/lib/CartService.ts
+++ b/src/lib/CartService.ts
@@ -41,6 +41,8 @@ export async function getCart(cartId: string) {
 		if (errorResponse.statusCode === 404) {
 			return undefined;
 		}
+
+		throw error;
 	}
 }
 

--- a/src/routes/cart/+page.server.ts
+++ b/src/routes/cart/+page.server.ts
@@ -53,7 +53,7 @@ export const actions = {
 				return fail(400, { addCouponCodeError: 'Invalid coupon code' });
 			}
 
-			console.error(error);
+			console.dir(error, { depth: null });
 
 			return fail(500, { addCouponCodeError: 'Failed to set coupon code' });
 		}
@@ -69,7 +69,7 @@ export const actions = {
 
 			return { cart: updatedCart };
 		} catch (error) {
-			console.error(error);
+			console.dir(error, { depth: null });
 			return fail(500, { removeCouponCodeError: 'Failed to remove coupon code' });
 		}
 	},
@@ -96,7 +96,7 @@ export const actions = {
 
 			return { cart: updatedCart };
 		} catch (error) {
-			console.error(error);
+			console.dir(error, { depth: null });
 			return fail(500, { updateItemQuantityError: 'Failed to update item quantity' });
 		}
 	},
@@ -115,7 +115,7 @@ export const actions = {
 
 			return { cart: updatedCart };
 		} catch (error) {
-			console.error(error);
+			console.dir(error, { depth: null });
 			return fail(500, { removeLineItemError: 'Failed to remove item' });
 		}
 	}

--- a/src/routes/product/[id]/+page.server.ts
+++ b/src/routes/product/[id]/+page.server.ts
@@ -45,18 +45,18 @@ export const actions: Actions = {
 		const cartId = cookies.get('cartId');
 		let cart;
 
-		if (!cartId) {
-			cart = await createCartAndSetCookie(cookies);
-		} else {
-			cart = await getCart(cartId);
-
-			// handle the cart not being valid even though we have an ID
-			if (!cart) {
-				cart = await createCartAndSetCookie(cookies);
-			}
-		}
-
 		try {
+			if (!cartId) {
+				cart = await createCartAndSetCookie(cookies);
+			} else {
+				cart = await getCart(cartId);
+
+				// handle the cart not being valid even though we have an ID
+				if (!cart) {
+					cart = await createCartAndSetCookie(cookies);
+				}
+			}
+
 			const updatedCart = await addLineItem(cart.id, cart.version, sku);
 
 			return {

--- a/src/routes/product/[id]/+page.server.ts
+++ b/src/routes/product/[id]/+page.server.ts
@@ -63,7 +63,7 @@ export const actions: Actions = {
 				cart: updatedCart
 			};
 		} catch (error) {
-			console.error(error);
+			console.dir(error, { depth: null });
 
 			const errorResponse = error as ClientResponse;
 

--- a/src/routes/set-customer/+page.server.ts
+++ b/src/routes/set-customer/+page.server.ts
@@ -37,7 +37,7 @@ export const actions: Actions = {
 
 			return { cart: updatedCart };
 		} catch (error) {
-			console.error(error);
+			console.dir(error, { depth: null });
 			return fail(500, { clearCustomerError: 'Failed to clear customer on cart' });
 		}
 	},
@@ -87,7 +87,7 @@ export const actions: Actions = {
 			const updatedCart = await setCustomer(cart.id, cart.version, customer.id, customer.email);
 			return { cart: updatedCart };
 		} catch (error) {
-			console.error(error);
+			console.dir(error, { depth: null });
 			return fail(500, { setCustomerError: 'Failed to set customer on cart' });
 		}
 	}


### PR DESCRIPTION
* Use console.dir with depth option for commercetools errors so we get the full error logged
* Add try catch around create cart to ensure errors here are caught
* Ensure if there is an error getting cart other than 404 this error is propagated